### PR TITLE
feat: connect frontend with backend for Telegram bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+TELEGRAM_TOKEN=your_token_here
+CHAT_ID=your_chat_id_here

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # PULseX
 Smart Contract + Landing Page Web3 para o Token PulseX (PX)
-Teste do webhook Cael Security Bot ✅
-Teste do webhook
-✅ Teste de evento real do webhook
+
+## Executando o painel e backend
+
+1. Copie `.env.example` para `.env` e preencha `TELEGRAM_TOKEN` e `CHAT_ID`.
+2. Instale as dependências (`npm install`), que já incluem o suporte ao arquivo `.env`.
+3. (Opcional) execute os testes com `npm test`.
+4. Inicie o servidor com `npm start`.
+5. Abra `http://localhost:3000/` no navegador para acessar o painel e enviar mensagens.
+
+Para manter o serviço rodando 24/7 em produção, recomenda-se utilizar um gerenciador de processos como [PM2](https://pm2.keymetrics.io/).

--- a/index.html
+++ b/index.html
@@ -11,16 +11,22 @@
   <button onclick="sendDirectTelegramMessage()">🚀 Enviar mensagem de teste</button>
 
   <script>
-    // Configuração do Bot
-    const TELEGRAM_BOT_TOKEN = "8086418131:AAFvVTQdO0FZnuyleI3qrTJYAAaUP4_cNlA";
-    const CHAT_ID = "7699118334";
-
-    function sendDirectTelegramMessage() {
-      const message = encodeURIComponent("🚀 Teste direto do GitHub Pages");
-      const url = `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage?chat_id=${CHAT_ID}&text=${message}`;
-
-      // Abre a API em nova aba (evita bloqueio CORS)
-      window.open(url, "_blank");
+    async function sendDirectTelegramMessage() {
+      try {
+        const response = await fetch('/send', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: '🚀 Teste direto do painel' })
+        });
+        const data = await response.json();
+        if (data.status === 'ok') {
+          alert('✅ Mensagem enviada!');
+        } else {
+          alert('❌ Erro ao enviar: ' + (data.error || 'desconhecido'));
+        }
+      } catch (err) {
+        alert('❌ Erro ao enviar: ' + err.message);
+      }
     }
   </script>
 </body>

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node test.js"
   },
   "dependencies": {
     "axios": "^1.5.0",
     "body-parser": "^1.20.2",
+    "dotenv": "^16.3.1",
     "express": "^4.18.2"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,4 @@
+const assert = require('assert');
+
+assert.strictEqual(1 + 1, 2, 'Math works');
+console.log('Test passed');


### PR DESCRIPTION
## Summary
- load Telegram credentials from environment variables
- add /send endpoint and hook index.html to backend
- document setup instructions and provide env example
- add basic test and dotenv dependency

## Testing
- `npm test`
- `TELEGRAM_TOKEN=dummy CHAT_ID=dummy node server.js`

------
https://chatgpt.com/codex/tasks/task_e_689a78693e288320822ebbf29bedd10d