### PR TITLE
Integrate frontend with backend Telegram service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/index.html
+++ b/index.html
@@ -6,21 +6,18 @@
 </head>
 <body>
   <h1>✅ PULseX - Conector do Cael Security Bot</h1>
-  <p>Esta página está conectada ao seu bot do Telegram.</p>
+  <p>Esta página está conectada ao seu bot do Telegram via backend.</p>
 
-  <button onclick="sendDirectTelegramMessage()">🚀 Enviar mensagem de teste</button>
+  <button onclick="sendTestMessage()">🚀 Enviar mensagem de teste</button>
 
   <script>
-    // Configuração do Bot
-    const TELEGRAM_BOT_TOKEN = "8086418131:AAFvVTQdO0FZnuyleI3qrTJYAAaUP4_cNlA";
-    const CHAT_ID = "7699118334";
-
-    function sendDirectTelegramMessage() {
-      const message = encodeURIComponent("🚀 Teste direto do GitHub Pages");
-      const url = `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage?chat_id=${CHAT_ID}&text=${message}`;
-
-      // Abre a API em nova aba (evita bloqueio CORS)
-      window.open(url, "_blank");
+    // Envia uma mensagem de teste para o backend, que repassa ao Telegram
+    async function sendTestMessage() {
+      await fetch('/send-message', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: '🚀 Teste direto do Frontend' })
+      });
     }
   </script>
 </body>

--- a/server.js
+++ b/server.js
@@ -5,9 +5,14 @@ const axios = require('axios');
 const app = express();
 app.use(bodyParser.json());
 
+// Servir os arquivos estáticos do diretório atual (frontend)
+app.use(express.static(__dirname));
+
 // === CONFIGURAÇÕES DO TELEGRAM ===
-const TELEGRAM_TOKEN = 'SEU_TOKEN_AQUI';
-const CHAT_ID = 'SEU_CHAT_ID_AQUI';
+// Os dados sensíveis agora vêm de variáveis de ambiente para não
+// expor o token no código-fonte do frontend
+const TELEGRAM_TOKEN = process.env.TELEGRAM_TOKEN;
+const CHAT_ID = process.env.CHAT_ID;
 
 // Função para enviar mensagem para o Telegram
 async function enviarTelegram(mensagem) {
@@ -25,7 +30,7 @@ async function enviarTelegram(mensagem) {
 
 // Rota básica para GET (teste manual)
 app.get('/', (req, res) => {
-  res.send("✅ PULseX Backend está ativo e ouvindo webhooks do GitHub!");
+  res.sendFile(__dirname + '/index.html');
 });
 
 // Webhook que recebe os eventos do GitHub
@@ -56,6 +61,13 @@ app.post('/webhook', async (req, res) => {
 
   // SEMPRE responde 200 OK para evitar erro 502
   res.status(200).json({ status: "ok", received_event: event });
+});
+
+// Endpoint para o frontend enviar mensagens ao Telegram
+app.post('/send-message', async (req, res) => {
+  const { message } = req.body;
+  await enviarTelegram(message || 'Mensagem vazia');
+  res.json({ status: 'ok' });
 });
 
 // Porta usada pelo Render


### PR DESCRIPTION
## Summary
- Serve static frontend assets from Express backend
- Accept POSTed messages from frontend and relay them to Telegram
- Use environment variables for Telegram token and chat ID
- Ignore node dependencies in version control

## Testing
- `npm test` *(fails: Missing script: "test")*
- `TELEGRAM_TOKEN=test CHAT_ID=123 npm start` (in separate shell)
- `curl -s http://localhost:3000/ | head -n 20`
- `curl -s -X POST http://localhost:3000/send-message -H 'Content-Type: application/json' -d '{"message":"Hello"}'`

------
https://chatgpt.com/codex/tasks/task_e_689a798eea8083208f8bb42be88c1909