### PR TITLE
infra: vercel proxy + backend hardening + health + rate-limit + ci + docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+.env

--- a/README.md
+++ b/README.md
@@ -1,5 +1,33 @@
-# PULseX
-Smart Contract + Landing Page Web3 para o Token PulseX (PX)
-Teste do webhook Cael Security Bot ✅
-Teste do webhook
-✅ Teste de evento real do webhook
+# PULseX infra
+
+Infraestrutura mínima para conectar o frontend da Vercel ao backend Express (Railway) que envia mensagens ao Telegram.
+
+## Desenvolvimento
+
+```bash
+npm install
+npm test         # executa smoke test com DRY_RUN
+TELEGRAM_TOKEN=seu_token CHAT_ID=123 node server.js
+```
+
+## Deploy
+
+### Railway (backend)
+1. Crie serviço a partir deste repositório.
+2. Defina variáveis:
+   - `TELEGRAM_TOKEN`
+   - `CHAT_ID`
+   - `DRY_RUN` (opcional em prod: `false`)
+   - `RATE_LIMIT_WINDOW_MS` e `RATE_LIMIT_MAX` (opcionais)
+3. Deploy e anote a URL pública (`https://xxxx.up.railway.app`).
+
+### Vercel (frontend + proxy)
+1. Importe o repositório na Vercel.
+2. Em **Environment Variables**, configure `BACKEND_URL` apontando para a URL da Railway.
+3. Opcional: configure domínio customizado e aponte DNS (CNAME) para a Vercel.
+
+## Endpoints
+
+- Frontend chama `POST /api/send-message` → Função Serverless → Railway `POST /send-message`.
+- Health check em `GET /api/health` (proxy para `/health`).
+

--- a/api/health.js
+++ b/api/health.js
@@ -1,0 +1,11 @@
+module.exports = async (_req, res) => {
+  const backend = process.env.BACKEND_URL;
+  if (!backend) return res.status(500).json({ error: 'Missing BACKEND_URL' });
+  try {
+    const r = await fetch(`${backend.replace(/\/$/, '')}/health`);
+    const data = await r.json();
+    res.status(r.status).json(data);
+  } catch (e) {
+    res.status(502).json({ error: 'Bad Gateway' });
+  }
+};

--- a/api/send-message.js
+++ b/api/send-message.js
@@ -1,0 +1,16 @@
+module.exports = async (req, res) => {
+  const backend = process.env.BACKEND_URL;
+  if (!backend) return res.status(500).json({ error: 'Missing BACKEND_URL' });
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method Not Allowed' });
+  try {
+    const r = await fetch(`${backend.replace(/\/$/, '')}/send-message`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-request-id': req.headers['x-request-id'] || '' },
+      body: JSON.stringify(req.body || {})
+    });
+    const data = await r.json();
+    res.status(r.status).json(data);
+  } catch (e) {
+    res.status(502).json({ error: 'Bad Gateway' });
+  }
+};

--- a/index.html
+++ b/index.html
@@ -6,21 +6,24 @@
 </head>
 <body>
   <h1>✅ PULseX - Conector do Cael Security Bot</h1>
-  <p>Esta página está conectada ao seu bot do Telegram.</p>
+  <p>Esta página está conectada ao seu bot do Telegram via backend.</p>
 
-  <button onclick="sendDirectTelegramMessage()">🚀 Enviar mensagem de teste</button>
+  <button onclick="sendTestMessage()">🚀 Enviar mensagem de teste</button>
+  <p id="status"></p>
 
   <script>
-    // Configuração do Bot
-    const TELEGRAM_BOT_TOKEN = "8086418131:AAFvVTQdO0FZnuyleI3qrTJYAAaUP4_cNlA";
-    const CHAT_ID = "7699118334";
-
-    function sendDirectTelegramMessage() {
-      const message = encodeURIComponent("🚀 Teste direto do GitHub Pages");
-      const url = `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage?chat_id=${CHAT_ID}&text=${message}`;
-
-      // Abre a API em nova aba (evita bloqueio CORS)
-      window.open(url, "_blank");
+    // Envia uma mensagem de teste para o backend, que repassa ao Telegram
+    async function sendTestMessage() {
+      try {
+          const res = await fetch('/api/send-message', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: '🚀 Teste direto do Frontend' })
+        });
+        document.getElementById('status').textContent = res.ok ? 'Mensagem enviada!' : 'Falha ao enviar';
+      } catch (err) {
+        document.getElementById('status').textContent = 'Erro de rede';
+      }
     }
   </script>
 </body>

--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "DRY_RUN=true node smoke.test.js"
   },
   "dependencies": {
     "axios": "^1.5.0",
-    "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "helmet": "^7.0.0"
   }
 }

--- a/smoke.test.js
+++ b/smoke.test.js
@@ -1,0 +1,25 @@
+process.env.PORT = 0;
+process.env.DRY_RUN = 'true';
+
+const axios = require('axios');
+const server = require('./server');
+
+const port = server.address().port;
+const baseURL = `http://localhost:${port}`;
+
+(async () => {
+  try {
+    const health = await axios.get(`${baseURL}/health`);
+    if (!health.data || !health.data.ok) throw new Error('health failed');
+
+    const send = await axios.post(`${baseURL}/send-message`, { message: 'test' });
+    if (!send.data || send.data.status !== 'ok') throw new Error('send failed');
+
+    console.log('smoke test passed');
+    server.close();
+  } catch (err) {
+    console.error(err);
+    server.close();
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- Harden Express backend with Helmet, request IDs, in-memory rate limit and retry logic; expose `/health` and canonical `/send-message` endpoint
- Add Vercel proxy functions for `/api/send-message` and `/api/health` backed by configurable `BACKEND_URL`
- Wire up CI workflow and document Railway/Vercel deployment and environment variables

## Testing
- `npm install` *(falhou: 403 Forbidden - GET https://registry.npmjs.org/helmet)*
- `npm test` *(falhou: Cannot find module 'helmet')*

------
https://chatgpt.com/codex/tasks/task_e_689a798eea8083208f8bb42be88c1909