### PR TITLE
infra: unify endpoints + env + DRY_RUN + health + smoke test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+TELEGRAM_TOKEN=your_token_here
+CHAT_ID=your_chat_id_here
+DRY_RUN=false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # PULseX
 Smart Contract + Landing Page Web3 para o Token PulseX (PX)
-Teste do webhook Cael Security Bot ✅
-Teste do webhook
-✅ Teste de evento real do webhook
+
+## Configuração
+1. Copie `.env.example` para `.env` e defina `TELEGRAM_TOKEN`, `CHAT_ID` e opcionalmente `DRY_RUN`.
+2. Instale as dependências (`npm install`).
+3. Rode os testes com `npm test`.
+4. Inicie o servidor com `npm start` e acesse `http://localhost:3000`.
+
+## Endpoints
+- `POST /send-message` – envia `{ "message": "texto" }` para o Telegram.
+- `POST /send` – alias temporário de `/send-message`.
+- `GET /health` – verifica se o backend está de pé.
+
+## Deploy 24/7
+Plataformas como **Vercel** ou **Railway** podem hospedar o serviço de forma contínua. Configure as variáveis de ambiente (`TELEGRAM_TOKEN`, `CHAT_ID`) e o comando de start (`npm start`).

--- a/index.html
+++ b/index.html
@@ -11,16 +11,22 @@
   <button onclick="sendDirectTelegramMessage()">🚀 Enviar mensagem de teste</button>
 
   <script>
-    // Configuração do Bot
-    const TELEGRAM_BOT_TOKEN = "8086418131:AAFvVTQdO0FZnuyleI3qrTJYAAaUP4_cNlA";
-    const CHAT_ID = "7699118334";
-
-    function sendDirectTelegramMessage() {
-      const message = encodeURIComponent("🚀 Teste direto do GitHub Pages");
-      const url = `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage?chat_id=${CHAT_ID}&text=${message}`;
-
-      // Abre a API em nova aba (evita bloqueio CORS)
-      window.open(url, "_blank");
+    async function sendDirectTelegramMessage() {
+      try {
+        const response = await fetch('/send-message', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: '🚀 Teste direto do painel' })
+        });
+        const data = await response.json();
+        if (data.status === 'ok') {
+          alert('✅ Mensagem enviada!');
+        } else {
+          alert('❌ Erro ao enviar: ' + (data.error || 'desconhecido'));
+        }
+      } catch (err) {
+        alert('❌ Erro ao enviar: ' + err.message);
+      }
     }
   </script>
 </body>

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "DRY_RUN=true node test.js"
   },
   "dependencies": {
     "axios": "^1.5.0",
     "body-parser": "^1.20.2",
+    "dotenv": "^16.3.1",
     "express": "^4.18.2"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+
+process.env.PORT = 0; // use ephemeral port for tests
+const server = require('./server');
+const port = server.address().port;
+
+async function run() {
+  const health = await fetch(`http://localhost:${port}/health`).then(r => r.json());
+  assert.strictEqual(health.ok, true, 'health check');
+
+  const resp = await fetch(`http://localhost:${port}/send-message`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message: 'test' })
+  }).then(r => r.json());
+  assert.strictEqual(resp.status, 'ok', 'send-message');
+
+  server.close();
+  console.log('Smoke test passed');
+}
+
+run().catch(err => {
+  server.close();
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add canonical `/send-message` endpoint, temporary `/send` alias, and `GET /health`
- support `DRY_RUN` environment flag and document setup and deploy steps
- add smoke test and example env file, updating frontend and test script

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dotenv)*
- `npm test` *(fails: Cannot find module 'express')*
- `TELEGRAM_TOKEN=dummy CHAT_ID=dummy DRY_RUN=true node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_689a78693e288320822ebbf29bedd10d